### PR TITLE
Added config option to TaskManager to allow node0 to be the preferred node and run tasks that are declared as "any" in taskmanager.rc

### DIFF
--- a/engine/server/application/TaskManager/src/shared/ConfigTaskManager.cpp
+++ b/engine/server/application/TaskManager/src/shared/ConfigTaskManager.cpp
@@ -82,6 +82,7 @@ void ConfigTaskManager::install(void)
 	KEY_INT     (maximumClockDriftToleranceSeconds, 10); // seconds
 	KEY_INT     (systemTimeCheckIntervalSeconds, 60); // seconds
 	KEY_INT     (clockDriftFatalIntervalSeconds, 1*60*60); // seconds
+	KEY_BOOL    (allowPreferredServerOnMasterNode, false);
 
 	int index = 0;
 	char const * result = 0;

--- a/engine/server/application/TaskManager/src/shared/ConfigTaskManager.h
+++ b/engine/server/application/TaskManager/src/shared/ConfigTaskManager.h
@@ -39,6 +39,7 @@ class ConfigTaskManager
 		int           maximumClockDriftToleranceSeconds;
 		int           systemTimeCheckIntervalSeconds;
 		int           clockDriftFatalIntervalSeconds;
+		bool          allowPreferredServerOnMasterNode; 
     };
 
 	static const bool    getAutoStart                   ();
@@ -68,7 +69,7 @@ class ConfigTaskManager
 	static int           getMaximumClockDriftToleranceSeconds();
 	static int           getSystemTimeCheckIntervalSeconds();
 	static int           getClockDriftFatalIntervalSeconds();
-
+	static const bool    getAllowPreferredServerOnMasterNode();
 	static void          install                        ();
 	static void          remove                         ();
 
@@ -266,6 +267,13 @@ inline int ConfigTaskManager::getSystemTimeCheckIntervalSeconds()
 inline int ConfigTaskManager::getClockDriftFatalIntervalSeconds()
 {
 	return data->clockDriftFatalIntervalSeconds;
+}
+
+// ----------------------------------------------------------------------
+
+inline const bool ConfigTaskManager::getAllowPreferredServerOnMasterNode()
+{
+	return data->allowPreferredServerOnMasterNode;
 }
 
 // ----------------------------------------------------------------------

--- a/engine/server/application/TaskManager/src/shared/Locator.h
+++ b/engine/server/application/TaskManager/src/shared/Locator.h
@@ -24,6 +24,7 @@ public:
 	static void install();
 	static void closed(std::string const &label, ManagerConnection const *oldConnection);
 	static ManagerConnection *getBestServer(std::string const &processName, std::string const &options, float cost);
+	static bool isMasterNodePreferred(std::string const &processName, std::string const &options, float cost);	
 	static float getMyLoad();
 	static float getMyMaximumLoad();
 	static float getServerLoad(std::string const &label);

--- a/engine/server/application/TaskManager/src/shared/ManagerConnection.cpp
+++ b/engine/server/application/TaskManager/src/shared/ManagerConnection.cpp
@@ -84,7 +84,7 @@ void ManagerConnection::onConnectionClosed()
 
 void ManagerConnection::onConnectionOpened()
 {
-	DEBUG_REPORT_LOG(true, ("Manager connection opened\n"));
+	DEBUG_REPORT_LOG(true, ("Manager connection opened for %s \n", getRemoteAddress().c_str()));
 	TaskConnectionIdMessage id(TaskConnectionIdMessage::TaskManager, TaskManager::getNodeLabel(), ConfigTaskManager::getClusterName());
 	send(id);
 	s_managerConnectionCount++;


### PR DESCRIPTION
This is a useful config setting I'm using for my multi node setup. By default TaskManager does not run processes that are declared as "any" in taskmanager.rc on the master node(aka node0). SOE never ran Planet or Game servers on the master node, but we should have an option to do so.