### PR TITLE
GU 16.9 - No Trade Removable

### DIFF
--- a/engine/server/library/serverGame/src/shared/object/ServerObject.h
+++ b/engine/server/library/serverGame/src/shared/object/ServerObject.h
@@ -230,6 +230,7 @@ public:
 	virtual bool                 markedNoTrade                  () const;
 	virtual bool                 markedNoTradeRecursive         (bool testPlayers, bool testOnlyContainedItems = false) const;
 	virtual bool                 markedNoTradeShared            (bool includeCheckForNoTrade) const;
+	virtual bool                 markedNoTradeRemovable         () const;
 	virtual bool                 isInBazaarOrVendor             () const;
 	virtual bool                 isInSecureTrade                () const;
 	virtual void				 removeAllAuctions				();

--- a/engine/server/library/serverGame/src/shared/object/TangibleObject.cpp
+++ b/engine/server/library/serverGame/src/shared/object/TangibleObject.cpp
@@ -4919,6 +4919,11 @@ void TangibleObject::getAttributes(AttributeVector & data) const
 		{
 			data.push_back(std::make_pair(SharedObjectAttributes::no_trade, Unicode::emptyString));
 
+			if (markedNoTradeRemovable())
+			{
+				data.push_back(std::make_pair(SharedObjectAttributes::no_trade_removable, Unicode::emptyString));
+			}
+
 			if (markedNoTradeShared(true))
 			{
 				data.push_back(std::make_pair(SharedObjectAttributes::no_trade_shared, Unicode::emptyString));
@@ -4930,6 +4935,11 @@ void TangibleObject::getAttributes(AttributeVector & data) const
 			if (gso && gso->hasScript(NOMOVE_SCRIPT))
 			{
 				data.push_back(std::make_pair(SharedObjectAttributes::no_trade, Unicode::emptyString));
+
+				if (markedNoTradeRemovable())
+				{
+					data.push_back(std::make_pair(SharedObjectAttributes::no_trade_removable, Unicode::emptyString));
+				}
 
 				if (markedNoTradeShared(false))
 				{

--- a/engine/shared/library/sharedGame/src/shared/core/SharedObjectAttributes.h
+++ b/engine/shared/library/sharedGame/src/shared/core/SharedObjectAttributes.h
@@ -95,6 +95,7 @@ namespace SharedObjectAttributes
 	MAKE_ATTRIB (bio_link);
 	MAKE_ATTRIB (no_trade);
 	MAKE_ATTRIB (no_trade_shared);
+	MAKE_ATTRIB (no_trade_removable);
 
 	MAKE_ATTRIB (unique);
 


### PR DESCRIPTION
**Summary**: Attaches the `item.special.no_trade_removable` script to any non-tradeable objects and attaches a special attribute to those objects to assist the client in displaying the correct "No Trade" badge at the top right of the details pane.

See https://github.com/SWG-Source/dsrc/pull/151 for full details on this change.
