### PR TITLE
Added handling of DTLA tags to server

### DIFF
--- a/engine/shared/library/sharedObject/src/shared/appearance/AppearanceTemplate.cpp
+++ b/engine/shared/library/sharedObject/src/shared/appearance/AppearanceTemplate.cpp
@@ -36,6 +36,7 @@
 namespace AppearanceTemplateNamespace
 {
 	const Tag TAG_APPR = TAG (A,P,P,R);
+	const Tag TAG_DTLA = TAG (D,T,L,A);
 	const Tag TAG_HPTS = TAG (H,P,T,S);
 	const Tag TAG_HPNT = TAG (H,P,N,T);
 	const Tag TAG_FLOR = TAG (F,L,O,R);
@@ -144,6 +145,7 @@ AppearanceTemplate::~AppearanceTemplate(void)
 void AppearanceTemplate::install()
 {
 	AppearanceTemplateList::assignBinding(TAG_APPR, create);
+	AppearanceTemplateList::assignBinding(TAG_DTLA, createDtla);
 
 	ms_crashReportInfo[0] = '\0';
 	CrashReportInformation::addDynamicText(ms_crashReportInfo);
@@ -169,6 +171,17 @@ AppearanceTemplate *AppearanceTemplate::create(const char *newName, Iff *iff)
 }
 
 // ----------------------------------------------------------------------
+
+AppearanceTemplate *AppearanceTemplate::createDtla(const char *newName, Iff *iff)
+{
+	iff->enterForm(TAG_DTLA);
+	Tag version = iff->getCurrentName();
+	iff->enterForm(version);
+	return create(newName, iff);
+}
+
+// ----------------------------------------------------------------------
+
 /**
  * Create a unique Appearance for this AppearanceTemplate.
  * 

--- a/engine/shared/library/sharedObject/src/shared/appearance/AppearanceTemplate.h
+++ b/engine/shared/library/sharedObject/src/shared/appearance/AppearanceTemplate.h
@@ -33,6 +33,7 @@ public:
 	static void install();
 
 	static AppearanceTemplate *create(const char *newName, Iff *iff);
+	static AppearanceTemplate *createDtla(const char *newName, Iff *iff);
 
 public:
 


### PR DESCRIPTION
As discussed on discord, this pull request adds handling to the server for the DTLA tag. With the new handling in place, this will allow us to use the original appearance files for both space combat and the ACM process.