### PR TITLE
Added parameter to control entertainer captcha from the server

### DIFF
--- a/engine/server/library/serverGame/src/shared/core/Client.cpp
+++ b/engine/server/library/serverGame/src/shared/core/Client.cpp
@@ -383,7 +383,8 @@ Client::Client(ConnectionServerConnection &connection, const NetworkId &characte
     }
 
     // Send server-specific settings to the client
-    ParametersMessage const msg(ConfigServerGame::getWeatherUpdateSeconds());
+    ParametersMessage const msg(ConfigServerGame::getWeatherUpdateSeconds(),
+		ConfigServerGame::getEntertainerCaptchaPercent());
     send(msg, true);
 
     ObjectTracker::addPlayer();

--- a/engine/server/library/serverGame/src/shared/core/ConfigServerGame.cpp
+++ b/engine/server/library/serverGame/src/shared/core/ConfigServerGame.cpp
@@ -170,6 +170,9 @@ void ConfigServerGame::install(void)
 	KEY_STRING  (defaultVendorItemRestrictionFile, "datatables/commodity/vendor_item_restriction_default.iff");
 	KEY_STRING  (defaultVendorItemRestrictionRejectionMessage, "@ui_auc:reject_restricted_item");
 	KEY_INT     (weatherUpdateSeconds, 15*60);
+	KEY_INT		(entertainerCaptchaPercent, 40);
+	data->entertainerCaptchaPercent = std::max(0, std::min(100, data->entertainerCaptchaPercent));
+
 	KEY_STRING  (instrumentDataTableFilename, "datatables/tangible/instrument_datatable.iff");
 	KEY_STRING  (performanceDataTableFilename, "datatables/performance/performance.iff");
 	KEY_INT     (createQueueScheduleTime, 75);

--- a/engine/server/library/serverGame/src/shared/core/ConfigServerGame.h
+++ b/engine/server/library/serverGame/src/shared/core/ConfigServerGame.h
@@ -229,6 +229,7 @@ class ConfigServerGame
 		const char *    defaultVendorItemRestrictionRejectionMessage;
 
 		int             weatherUpdateSeconds;
+		int				entertainerCaptchaPercent;
 
 		const char *    instrumentDataTableFilename;
 		const char *    performanceDataTableFilename;
@@ -768,6 +769,7 @@ class ConfigServerGame
 	static const char *     getDefaultVendorItemRestrictionRejectionMessage();
 
 	static int              getWeatherUpdateSeconds();
+	static int				getEntertainerCaptchaPercent();
 	static const char *     getInstrumentDataTableFilename(void);
 	static const char *     getPerformanceDataTableFilename(void);
 	static const int        getCreateQueueScheduleTime(void);
@@ -2005,6 +2007,13 @@ inline int ConfigServerGame::getWeatherUpdateSeconds(void)
 {
 	return data->weatherUpdateSeconds;
 }
+
+
+inline int ConfigServerGame::getEntertainerCaptchaPercent(void)
+{
+	return data->entertainerCaptchaPercent;
+}
+
 
 // ----------------------------------------------------------------------
 

--- a/engine/shared/library/sharedNetworkMessages/src/shared/clientGameServer/ParametersMessage.cpp
+++ b/engine/shared/library/sharedNetworkMessages/src/shared/clientGameServer/ParametersMessage.cpp
@@ -10,20 +10,24 @@
 
 // ======================================================================
 
-ParametersMessage::ParametersMessage(int weatherUpdateInterval) :
+ParametersMessage::ParametersMessage(int weatherUpdateInterval, int entertainerCaptchaPercent) :
 		GameNetworkMessage("ParametersMessage"),
-		m_weatherUpdateInterval(weatherUpdateInterval)
+		m_weatherUpdateInterval(weatherUpdateInterval),
+		m_entertainerCaptchaPercent(entertainerCaptchaPercent)
 {
 	addVariable(m_weatherUpdateInterval);
+	addVariable(m_entertainerCaptchaPercent);
 }
 
 //-----------------------------------------------------------------------
 
 ParametersMessage::ParametersMessage(Archive::ReadIterator & source) :
 		GameNetworkMessage("ParametersMessage"),
-		m_weatherUpdateInterval()
+		m_weatherUpdateInterval(),
+		m_entertainerCaptchaPercent()
 {
 	addVariable(m_weatherUpdateInterval);
+	addVariable(m_entertainerCaptchaPercent);
 
 	unpack(source);
 }

--- a/engine/shared/library/sharedNetworkMessages/src/shared/clientGameServer/ParametersMessage.h
+++ b/engine/shared/library/sharedNetworkMessages/src/shared/clientGameServer/ParametersMessage.h
@@ -31,15 +31,17 @@
 class ParametersMessage : public GameNetworkMessage
 {
   public:
-	ParametersMessage(int weatherUpdateInterval);
+	ParametersMessage(int weatherUpdateInterval, int entertainerCaptchaPercent);
 	explicit ParametersMessage(Archive::ReadIterator & source);
 	virtual ~ParametersMessage();
 
   public:
 	int getWeatherUpdateInterval() const;
+	int getEntertainerCaptchaPercent() const;
 	
   private:
 	Archive::AutoVariable<int> m_weatherUpdateInterval;
+	Archive::AutoVariable<int> m_entertainerCaptchaPercent;
 
 	ParametersMessage();
 	ParametersMessage(const ParametersMessage&);
@@ -53,6 +55,14 @@ inline int ParametersMessage::getWeatherUpdateInterval() const
 	return m_weatherUpdateInterval.get();
 }
 
+inline int ParametersMessage::getEntertainerCaptchaPercent() const
+{
+	return m_entertainerCaptchaPercent.get();
+}
+
+
+
 // ======================================================================
 
 #endif
+


### PR DESCRIPTION
Added a server-side parameter to control the entertainer captcha percent on the client.

The default remains 40. To disable the entertainer captcha, set the value to zero:

[GameServer]
entertainerCaptchaPercent=0